### PR TITLE
docs: correct spelling

### DIFF
--- a/catalogue/apps/io.pilot.postgres/metadata.json
+++ b/catalogue/apps/io.pilot.postgres/metadata.json
@@ -79,7 +79,7 @@
     },
     {
       "name": "postgres.list",
-      "summary": "List the databases on the server (owner, encoding, collation, access privileges) as an aligned table — a quick connectivity + inventory chec"
+      "summary": "List the databases on the server (owner, encoding, collation, access privileges) as an aligned table — a quick connectivity + inventory check"
     },
     {
       "name": "postgres.exec",

--- a/pkg/daemon/zz_daemonapi_conformance.go
+++ b/pkg/daemon/zz_daemonapi_conformance.go
@@ -17,7 +17,7 @@ import (
 // daemonapi.Connection requires Info() ConnectionInfo. Bolted onto
 // *Connection here (rather than ports.go) so the I/O-heavy types in
 // ports.go stay free of plugin-API concerns and the interface
-// fulfilment lives next to its adapter siblings.
+// fulfillment lives next to its adapter siblings.
 
 // Info returns an endpoint snapshot for plugin consumption. Required
 // by daemonapi.Connection (common@v0.4.3).


### PR DESCRIPTION
# Pull Request

## Summary

This pull request includes spelling corrections to documentation and metadata files.

## Changes

* Corrected the spelling of "chec" to "check" in `catalogue/apps/io.pilot.postgres/metadata.json`
* Corrected the spelling of "fulfilment" to "fulfillment" in `pkg/daemon/zz_daemonapi_conformance.go`.

## Test Plan

- [X] `go build ./cmd/...` succeeds
- [X] `go vet ./...` clean
- [X] Relevant tests pass (`go test -parallel 4 ./tests/ ./pkg/beacon/`)
- [X] Pre-commit hooks pass (`pre-commit run --all-files`)

## Checklist

- [ ] New code includes the SPDX license header
- [X] No secrets or credentials committed
- [ ] `go.mod` / `go.sum` changes are intentional
- [ ] Documentation updated if behavior changed
- [ ] Linked issue or context: <!-- #issue-number -->