### PR TITLE
catalogue: com.comos-federation.connector v0.1.0 (ComOS Federation)

### DIFF
--- a/catalogue/apps/com.comos-federation.connector/metadata.json
+++ b/catalogue/apps/com.comos-federation.connector/metadata.json
@@ -1,0 +1,108 @@
+{
+  "schema_version": 1,
+  "id": "com.comos-federation.connector",
+  "display_name": "ComOS Federation",
+  "tagline": "The ComOS federation's public surfaces, from Pilot.",
+  "description_md": "ComOS is an AI-native operating system for commerce, run by ComOS Federation Inc. A business runs as a tenant that composes platforms \u2014 retail, bookings, services, rentals, digital goods, shipping, messaging, and more \u2014 and AI agents reach every merchant on the network through one federated MCP endpoint.\n\nThis connector is a thin read-only client for that network's public surfaces. Each method proxies one tokenless tool on the federation gateway at `mcp.comos-federation.com`, over HTTPS, with a single `net.dial` grant to that host. It holds no credentials, keeps no state, and writes nothing.\n\nDiscovery and reads need no token. Selling on the network requires passing an admittance door; `comos.offer` returns the current offer and how to apply directly at the gateway. This connector never performs admission.\n\nCost of the connector: none. Cost on the network: free to join and operate; 6% when buying Coms; 3% when a sale settles. No subscription, no seat, no minimum.",
+  "vendor": {
+    "name": "ComOS Federation, Inc.",
+    "url": "https://comos-federation.com",
+    "publisher_pubkey": "ed25519:IB9iTy70SyMHnQjG1rMtOoXf3KIE3uDZpElGpBw5fUw="
+  },
+  "homepage": "https://comos-federation.com",
+  "source_url": "https://github.com/ronrey/comos-pilot-connector",
+  "license": "AGPL-3.0-or-later",
+  "categories": [
+    "commerce",
+    "retail",
+    "payments"
+  ],
+  "keywords": [
+    "comos",
+    "commerce",
+    "federation",
+    "mcp",
+    "retail",
+    "bookings"
+  ],
+  "size": {
+    "bundle_bytes": 2542631
+  },
+  "compat": {
+    "min_pilot_version": "1.0.0",
+    "runtimes": [
+      "go"
+    ]
+  },
+  "methods": [
+    {
+      "name": "comos.help",
+      "summary": "Usage guide for the federation gateway: list, enter, use."
+    },
+    {
+      "name": "comos.why",
+      "summary": "Why the federation exists, from its own motivation surface."
+    },
+    {
+      "name": "comos.offer",
+      "summary": "The standing offer to vendors and how to apply for admission."
+    },
+    {
+      "name": "comos.search",
+      "summary": "Route an intent to the platforms that serve it."
+    },
+    {
+      "name": "comos.platforms",
+      "summary": "The composable platform catalog."
+    },
+    {
+      "name": "comos.agents",
+      "summary": "The agent-level catalog."
+    },
+    {
+      "name": "comos.arena",
+      "summary": "Settlement-signed reputation leaderboard."
+    },
+    {
+      "name": "comos.pricesheet",
+      "summary": "Per-act prices; reading it is always free."
+    },
+    {
+      "name": "comos.latency",
+      "summary": "Measured p50/p95/p99 of recent gateway calls."
+    },
+    {
+      "name": "comos.solvency",
+      "summary": "Whether the Com float is backed, without naming tenants."
+    },
+    {
+      "name": "comos.governance",
+      "summary": "How resident agents are governed: autonomy ladder, clamps, standing."
+    },
+    {
+      "name": "comos.legal",
+      "summary": "Terms, privacy, DPA, retention \u2014 the served legal instruments."
+    }
+  ],
+  "changelog": [
+    {
+      "version": "0.1.0",
+      "date": "2026-08-28",
+      "notes": [
+        "Initial release: 12 read-only methods proxying the federation gateway's public tools."
+      ]
+    }
+  ],
+  "links": [
+    {
+      "label": "Machine-readable overview (llms.txt)",
+      "url": "https://mcp.comos-federation.com/llms.txt"
+    },
+    {
+      "label": "AI guide (ai.txt)",
+      "url": "https://mcp.comos-federation.com/ai.txt"
+    }
+  ],
+  "published_at": "2026-08-28T21:00:00Z",
+  "updated_at": "2026-08-28T21:00:00Z"
+}

--- a/catalogue/catalogue.json
+++ b/catalogue/catalogue.json
@@ -1,11 +1,11 @@
 {
   "version": 2,
-  "updated_at": "2026-07-03T00:00:00Z",
+  "updated_at": "2026-08-28T21:00:00Z",
   "apps": [
     {
       "id": "io.pilot.wallet",
       "version": "0.3.3",
-      "description": "On-overlay USDC payments — multichain (Base + Ethereum + Polygon).",
+      "description": "On-overlay USDC payments \u2014 multichain (Base + Ethereum + Polygon).",
       "bundle_url": "https://github.com/pilot-protocol/pilotprotocol/releases/download/wallet-v0.3.3/io.pilot.wallet-0.3.3.tar.gz",
       "bundle_sha256": "8d30b4331bc025c327dd2d8610362984cc9365843176e21b96a2637d8e18ff54",
       "display_name": "Wallet",
@@ -84,14 +84,14 @@
       "id": "io.pilot.smolmachines",
       "renamed_to": "io.pilot.smol",
       "hidden": true,
-      "display_name": "Smol Machines (renamed → io.pilot.smol)",
-      "description": "Renamed to io.pilot.smol. Install io.pilot.smol — it is the same app plus a cloud plane. This tombstone entry is retained only to keep already-installed copies running and to redirect the old id; it is not listed and is not installable.",
+      "display_name": "Smol Machines (renamed \u2192 io.pilot.smol)",
+      "description": "Renamed to io.pilot.smol. Install io.pilot.smol \u2014 it is the same app plus a cloud plane. This tombstone entry is retained only to keep already-installed copies running and to redirect the old id; it is not listed and is not installable.",
       "publisher": "ed25519:3QJm6H6OdjtfrF+Es1lrRjfFmdtq2tGvVSWxia63vcI="
     },
     {
       "id": "io.telepat.ideon-free",
       "version": "0.3.1",
-      "description": "Free article generation for agents: ideon-free.generate(idea) returns a jobId; ideon-free.poll(jobId) returns the finished markdown article. Thin adapter over Ideon's ideon_write — no payment.",
+      "description": "Free article generation for agents: ideon-free.generate(idea) returns a jobId; ideon-free.poll(jobId) returns the finished markdown article. Thin adapter over Ideon's ideon_write \u2014 no payment.",
       "bundle_url": "https://github.com/pilot-protocol/catalog/releases/download/ideon-free-v0.3.1/io.telepat.ideon-free-0.3.1.tar.gz",
       "bundle_sha256": "dd8e37057f33eadefff6b7ff5fc99130667076ea398c10a154c345fd87dd1ad6",
       "publisher": "ed25519:5cqj+zTVecj8r0YRUShpgFi/g7TxDg1lkDKQzfNyDyc=",
@@ -101,7 +101,7 @@
     {
       "id": "io.pilot.slipstream",
       "version": "1.0.0",
-      "description": "SLIPSTREAM — Polymarket smart-money leaderboard, signals, tape & opportunities (Ed25519-signed API).",
+      "description": "SLIPSTREAM \u2014 Polymarket smart-money leaderboard, signals, tape & opportunities (Ed25519-signed API).",
       "bundle_url": "https://github.com/pilot-protocol/catalog/releases/download/slipstream-v1.0.0/io.pilot.slipstream-1.0.0.tar.gz",
       "bundle_sha256": "8f19c06c886b97abb1272e8f657773950bee747c58dab8493d454742313ef2f5",
       "display_name": "Slipstream",
@@ -131,7 +131,7 @@
     {
       "id": "io.pilot.miren",
       "version": "0.1.0",
-      "description": "Operate the Miren PaaS from an agent: deploy and roll back apps; inspect status, logs, and history; run the server; and diagnose connectivity — plus a passthrough exec for any miren subcommand.",
+      "description": "Operate the Miren PaaS from an agent: deploy and roll back apps; inspect status, logs, and history; run the server; and diagnose connectivity \u2014 plus a passthrough exec for any miren subcommand.",
       "display_name": "Miren",
       "vendor": "Miren",
       "license": "Proprietary",
@@ -163,7 +163,7 @@
     {
       "id": "io.pilot.otto",
       "version": "0.20.0",
-      "description": "Drive real Chrome tabs from an agent: extract page content as markdown or HTML, run site commands (Reddit, LinkedIn, Hacker News, Google), screenshot pages, and inspect relay and node status — over a relay to a browser extension, no headless farm. Plus a passthrough exec for any otto subcommand.",
+      "description": "Drive real Chrome tabs from an agent: extract page content as markdown or HTML, run site commands (Reddit, LinkedIn, Hacker News, Google), screenshot pages, and inspect relay and node status \u2014 over a relay to a browser extension, no headless farm. Plus a passthrough exec for any otto subcommand.",
       "display_name": "Otto",
       "vendor": "Telepat",
       "license": "MIT",
@@ -227,7 +227,7 @@
     {
       "id": "io.pilot.postgres",
       "version": "17.5.0",
-      "description": "PostgreSQL 17.5.0 as a native CLI for agents: stand up and manage a local Postgres server (initdb / start / stop / createdb) and run SQL with psql — aligned-table or CSV results, backslash schema introspection, database listing, and the full client/server toolchain (pg_dump, pg_restore, pg_isready, ...) via a verbatim-argv passthrough. Connects to a local or remote server via a libpq connection string or PG* env.",
+      "description": "PostgreSQL 17.5.0 as a native CLI for agents: stand up and manage a local Postgres server (initdb / start / stop / createdb) and run SQL with psql \u2014 aligned-table or CSV results, backslash schema introspection, database listing, and the full client/server toolchain (pg_dump, pg_restore, pg_isready, ...) via a verbatim-argv passthrough. Connects to a local or remote server via a libpq connection string or PG* env.",
       "display_name": "PostgreSQL",
       "vendor": "Pilot Protocol",
       "license": "PostgreSQL",
@@ -259,7 +259,7 @@
     {
       "id": "io.pilot.duckdb",
       "version": "1.5.4",
-      "description": "DuckDB 1.5.4 as a native CLI for agents: an in-process analytical SQL database (think \"SQLite for analytics\") with zero server and zero provisioning. Run SQL in-memory or against a DuckDB file and query CSV, Parquet, and JSON files directly with no import step — results as an aligned table, CSV, JSON, or Markdown. Schema/table introspection, run a .sql script, and the full CLI surface (every flag + dot-command) via a verbatim-argv passthrough. Ideal for sandboxed agents that need real SQL locally without an AWS/GCP account.",
+      "description": "DuckDB 1.5.4 as a native CLI for agents: an in-process analytical SQL database (think \"SQLite for analytics\") with zero server and zero provisioning. Run SQL in-memory or against a DuckDB file and query CSV, Parquet, and JSON files directly with no import step \u2014 results as an aligned table, CSV, JSON, or Markdown. Schema/table introspection, run a .sql script, and the full CLI surface (every flag + dot-command) via a verbatim-argv passthrough. Ideal for sandboxed agents that need real SQL locally without an AWS/GCP account.",
       "display_name": "DuckDB",
       "vendor": "Pilot Protocol",
       "license": "MIT",
@@ -298,7 +298,7 @@
     {
       "id": "io.pilot.docker",
       "version": "29.6.1",
-      "description": "Docker 29.6.1 as a native CLI for agents (Linux): delivers the Docker Engine (dockerd + containerd + runc) and the docker CLI, sha-pinned. Start a local engine (docker.engine_start), then pull images and run containers — run/ps/images/pull/logs, plus build, exec, networks, volumes, and any docker command via a verbatim-argv passthrough. Real containers on a real Linux host, no Docker Desktop.",
+      "description": "Docker 29.6.1 as a native CLI for agents (Linux): delivers the Docker Engine (dockerd + containerd + runc) and the docker CLI, sha-pinned. Start a local engine (docker.engine_start), then pull images and run containers \u2014 run/ps/images/pull/logs, plus build, exec, networks, volumes, and any docker command via a verbatim-argv passthrough. Real containers on a real Linux host, no Docker Desktop.",
       "display_name": "Docker",
       "vendor": "Pilot Protocol",
       "license": "Apache-2.0",
@@ -329,7 +329,7 @@
     {
       "id": "io.pilot.redis",
       "version": "8.6.2",
-      "description": "Redis 8.6.2 as a native CLI for agents: stand up a local in-memory data store (redis.start) and talk to it with redis-cli — SET/GET, PING, INFO, DBSIZE, and ANY Redis command (lists, hashes, sets, sorted sets, streams, pub/sub, transactions) via a verbatim-argv passthrough. Server lifecycle (start/stop), health checks, and the full redis-cli/redis-server toolchain (redis-benchmark, redis-check-rdb, ...). No server to provision — runs locally on this host.",
+      "description": "Redis 8.6.2 as a native CLI for agents: stand up a local in-memory data store (redis.start) and talk to it with redis-cli \u2014 SET/GET, PING, INFO, DBSIZE, and ANY Redis command (lists, hashes, sets, sorted sets, streams, pub/sub, transactions) via a verbatim-argv passthrough. Server lifecycle (start/stop), health checks, and the full redis-cli/redis-server toolchain (redis-benchmark, redis-check-rdb, ...). No server to provision \u2014 runs locally on this host.",
       "display_name": "Redis",
       "vendor": "Pilot Protocol",
       "license": "AGPL-3.0",
@@ -368,7 +368,7 @@
     {
       "id": "io.pilot.aegis",
       "version": "0.1.3",
-      "description": "AEGIS 0.1.3 — a runtime firewall for AI agents (native CLI): scan files, commands, and tool results for prompt injection, jailbreaks, homoglyph/leetspeak obfuscation, and impersonation before your agent acts on them. L1 Aho-Corasick patterns plus an optional local Qwen3-1.7B judge, fully offline; an 880 KB binary. The scan-cmd/scan-result blocking gates run via aegis.exec (allow 0 / block 2); plus aegis.scan / status / targets / config.",
+      "description": "AEGIS 0.1.3 \u2014 a runtime firewall for AI agents (native CLI): scan files, commands, and tool results for prompt injection, jailbreaks, homoglyph/leetspeak obfuscation, and impersonation before your agent acts on them. L1 Aho-Corasick patterns plus an optional local Qwen3-1.7B judge, fully offline; an 880 KB binary. The scan-cmd/scan-result blocking gates run via aegis.exec (allow 0 / block 2); plus aegis.scan / status / targets / config.",
       "display_name": "AEGIS",
       "vendor": "Pilot Protocol",
       "license": "MIT",
@@ -402,7 +402,7 @@
     {
       "id": "io.pilot.smol",
       "version": "1.2.0",
-      "description": "Smol Machines — fast, hardware-isolated Linux microVMs, now local AND cloud. Create/run sub-second microVMs locally with the smolvm CLI, then push a VM to the smol cloud with smol.push. Pilot provisions a per-user cloud key automatically; cloud VMs are isolated per user and billed by real usage against $5 free credit.",
+      "description": "Smol Machines \u2014 fast, hardware-isolated Linux microVMs, now local AND cloud. Create/run sub-second microVMs locally with the smolvm CLI, then push a VM to the smol cloud with smol.push. Pilot provisions a per-user cloud key automatically; cloud VMs are isolated per user and billed by real usage against $5 free credit.",
       "display_name": "Smol Machines",
       "vendor": "smol machines",
       "license": "Apache-2.0",
@@ -484,7 +484,7 @@
     {
       "id": "io.pilot.sqlite",
       "version": "3.45.2",
-      "description": "SQLite 3.45.2 as a native SQL database for agents: a zero-server, single-file, transactional (OLTP) SQL engine delivered to the host and fronted as typed methods. Run SQL against a .db file or an in-memory database and get rows back as JSON, run a multi-statement script, introspect the schema and table list, and reach the full sqlite3 CLI (every dot-command and flag — .dump, .import, .backup, CSV/table/markdown output, …) via a verbatim-argv passthrough. The durable, on-disk complement to DuckDB's in-memory analytics — real transactional SQL locally with no server, no provisioning, and no cloud account.",
+      "description": "SQLite 3.45.2 as a native SQL database for agents: a zero-server, single-file, transactional (OLTP) SQL engine delivered to the host and fronted as typed methods. Run SQL against a .db file or an in-memory database and get rows back as JSON, run a multi-statement script, introspect the schema and table list, and reach the full sqlite3 CLI (every dot-command and flag \u2014 .dump, .import, .backup, CSV/table/markdown output, \u2026) via a verbatim-argv passthrough. The durable, on-disk complement to DuckDB's in-memory analytics \u2014 real transactional SQL locally with no server, no provisioning, and no cloud account.",
       "display_name": "SQLite",
       "vendor": "Pilot Protocol",
       "license": "blessing",
@@ -522,7 +522,7 @@
     {
       "id": "io.pilot.agentphone",
       "version": "0.3.1",
-      "description": "Give your AI agent a real US/Canada phone number: place and receive voice calls, send and receive SMS/iMessage, and hold threaded conversations — all over REST, metered per user against a $5 budget.",
+      "description": "Give your AI agent a real US/Canada phone number: place and receive voice calls, send and receive SMS/iMessage, and hold threaded conversations \u2014 all over REST, metered per user against a $5 budget.",
       "display_name": "AgentPhone",
       "vendor": "AgentPhone",
       "license": "Apache-2.0",
@@ -554,7 +554,7 @@
     {
       "id": "io.pilot.insforge",
       "version": "1.0.0",
-      "description": "The agent-native cloud (an AWS for agents) as ONE Pilot app. insforge.signup provisions your OWN isolated InsForge backend in one call — no email, no browser: a dedicated Postgres database, authentication, S3-style storage, Deno edge functions, and a Model Gateway OpenRouter key seeded with $1 of AI credits. Pilot's broker mints and manages the account; every method then talks directly to your backend, authenticated as you. Free to provision — pay only for what your backend uses.",
+      "description": "The agent-native cloud (an AWS for agents) as ONE Pilot app. insforge.signup provisions your OWN isolated InsForge backend in one call \u2014 no email, no browser: a dedicated Postgres database, authentication, S3-style storage, Deno edge functions, and a Model Gateway OpenRouter key seeded with $1 of AI credits. Pilot's broker mints and manages the account; every method then talks directly to your backend, authenticated as you. Free to provision \u2014 pay only for what your backend uses.",
       "bundle_url": "https://pub-f09f9a4ea848491198d48e329ba030e3.r2.dev/bundles/io.pilot.insforge/1.0.0/io.pilot.insforge-1.0.0-linux-amd64.tar.gz",
       "bundle_sha256": "9e1d05248b99dd66e1482aeda23ece61b2b110601c7848e3fb716f4a79ba47b6",
       "display_name": "Insforge",
@@ -588,7 +588,7 @@
     {
       "id": "io.pilot.orthogonal",
       "version": "0.1.1",
-      "description": "Connect your agent to Orthogonal — one key fronting 58 paid APIs / 851 endpoints (lead & contact enrichment, email & phone finding, web & social scraping, AI search, company/people/jobs data, weather, voice). Describe a task in plain English and Orthogonal's router returns the exact APIs to call; execute any of them through a single run, billed at the real per-call price and metered against a per-user $5 budget. Discovery, pricing and balance calls are free.",
+      "description": "Connect your agent to Orthogonal \u2014 one key fronting 58 paid APIs / 851 endpoints (lead & contact enrichment, email & phone finding, web & social scraping, AI search, company/people/jobs data, weather, voice). Describe a task in plain English and Orthogonal's router returns the exact APIs to call; execute any of them through a single run, billed at the real per-call price and metered against a per-user $5 budget. Discovery, pricing and balance calls are free.",
       "bundle_url": "https://pub-f09f9a4ea848491198d48e329ba030e3.r2.dev/bundles/io.pilot.orthogonal/0.1.1/io.pilot.orthogonal-0.1.1-linux-amd64.tar.gz",
       "bundle_sha256": "3f2c9bfc009e41898b36ff2e88a313c0c3bc8bb39500f9673572a1d40b84fac7",
       "display_name": "Orthogonal",
@@ -622,7 +622,7 @@
     {
       "id": "io.pilot.mysql",
       "version": "9.7.1",
-      "description": "MySQL 9.7.1 server + client as a native CLI for agents: a full, real client/server SQL database that runs entirely locally with no cloud account and no provisioning. Initialize a data directory, start a server on 127.0.0.1, create databases, and run SQL — results as an aligned table or TSV — with the actual InnoDB engine (transactions, foreign keys, triggers, JSON, window functions). Lifecycle (initialize/start/stop/ping), createdb, query/query_tsv, databases/tables listing, mysqldump, and the full tool surface via a verbatim-argv passthrough. The transactional server-grade sibling of io.pilot.sqlite and io.pilot.postgres.",
+      "description": "MySQL 9.7.1 server + client as a native CLI for agents: a full, real client/server SQL database that runs entirely locally with no cloud account and no provisioning. Initialize a data directory, start a server on 127.0.0.1, create databases, and run SQL \u2014 results as an aligned table or TSV \u2014 with the actual InnoDB engine (transactions, foreign keys, triggers, JSON, window functions). Lifecycle (initialize/start/stop/ping), createdb, query/query_tsv, databases/tables listing, mysqldump, and the full tool surface via a verbatim-argv passthrough. The transactional server-grade sibling of io.pilot.sqlite and io.pilot.postgres.",
       "bundle_url": "https://pub-f09f9a4ea848491198d48e329ba030e3.r2.dev/bundles/io.pilot.mysql/9.7.1/io.pilot.mysql-9.7.1-linux-amd64.tar.gz",
       "bundle_sha256": "74e57bee2b99cbef1cc10a1120894c6872027766509f0d8d4b252b93d1d0a9e1",
       "display_name": "Mysql",
@@ -656,7 +656,7 @@
     {
       "id": "io.pilot.didit",
       "version": "1.0.0",
-      "description": "Full Didit identity-verification platform over one HTTPS app — KYC/ID, liveness, face match, AML, proof-of-address, database validation, email/phone OTP, plus hosted sessions, workflows, users, billing, blocklists, questionnaires and webhooks. didit.signup mints your own Didit API key in ONE call with no email and no code (Pilot's broker handles the whole signup), caches it locally, and then every method authenticates as you and bills to your own Didit balance (500 free full-KYC checks/month).",
+      "description": "Full Didit identity-verification platform over one HTTPS app \u2014 KYC/ID, liveness, face match, AML, proof-of-address, database validation, email/phone OTP, plus hosted sessions, workflows, users, billing, blocklists, questionnaires and webhooks. didit.signup mints your own Didit API key in ONE call with no email and no code (Pilot's broker handles the whole signup), caches it locally, and then every method authenticates as you and bills to your own Didit balance (500 free full-KYC checks/month).",
       "bundle_url": "https://pub-f09f9a4ea848491198d48e329ba030e3.r2.dev/bundles/io.pilot.didit/1.0.0/io.pilot.didit-1.0.0-linux-amd64.tar.gz",
       "bundle_sha256": "57c63cf5c51c10871273126b408dae17e2c4cffc5330342d96c648ca95aa29d5",
       "display_name": "Didit",
@@ -690,7 +690,7 @@
     {
       "id": "io.pilot.tldr",
       "version": "1.13.1",
-      "description": "tldr (tlrc 1.13.1) as native, example-first documentation for agents: simplified, community-driven man pages for ~7,350+ command-line tools, delivered to the host and fronted as typed methods. Look up a command's cheat-sheet as clean text or raw Markdown, search the whole catalog by keyword, list the directory of documented tools, refresh or inspect the local cache, render a local page, and reach every client flag (--platform, --language, --list-all, --offline, …) via a verbatim-argv passthrough. Open source — MIT client, CC-BY-4.0 pages — self-contained and offline after the first fetch, on macOS and Linux.",
+      "description": "tldr (tlrc 1.13.1) as native, example-first documentation for agents: simplified, community-driven man pages for ~7,350+ command-line tools, delivered to the host and fronted as typed methods. Look up a command's cheat-sheet as clean text or raw Markdown, search the whole catalog by keyword, list the directory of documented tools, refresh or inspect the local cache, render a local page, and reach every client flag (--platform, --language, --list-all, --offline, \u2026) via a verbatim-argv passthrough. Open source \u2014 MIT client, CC-BY-4.0 pages \u2014 self-contained and offline after the first fetch, on macOS and Linux.",
       "bundle_url": "https://pub-f09f9a4ea848491198d48e329ba030e3.r2.dev/bundles/io.pilot.tldr/1.13.1/io.pilot.tldr-1.13.1-linux-amd64.tar.gz",
       "bundle_sha256": "0e73bc90fcf6fd62972cf08171b2c8e56cd2adf43b42e01afdb529f084bc1407",
       "display_name": "Tldr",
@@ -874,7 +874,7 @@
     {
       "id": "io.pilot.rentahuman",
       "version": "0.2.0",
-      "description": "Hire a real person for a physical-world task — a clean, a pickup, an errand, an on-site check — by describing it in plain language. A human ops coordinator sources and vets someone, then talks to your agent through a message thread until the work is done.",
+      "description": "Hire a real person for a physical-world task \u2014 a clean, a pickup, an errand, an on-site check \u2014 by describing it in plain language. A human ops coordinator sources and vets someone, then talks to your agent through a message thread until the work is done.",
       "bundle_url": "https://pub-f09f9a4ea848491198d48e329ba030e3.r2.dev/bundles/io.pilot.rentahuman/0.2.0/io.pilot.rentahuman-0.2.0-linux-amd64.tar.gz",
       "bundle_sha256": "9c1356527958da2c0e19f7a087a9f2e29eefba149fd01dc270645915a9c02fcb",
       "display_name": "Rent A Human",
@@ -945,6 +945,43 @@
         }
       },
       "publisher": "ed25519:zIs4w96eibc78b08fI5FtJFSAliQ+veFSeBFThkFNjw="
+    },
+    {
+      "id": "com.comos-federation.connector",
+      "version": "0.1.0",
+      "description": "Read-only access to the ComOS commerce federation: catalog, pricing, reputation, and governance over its public gateway.",
+      "bundle_url": "https://github.com/ronrey/comos-pilot-connector/releases/download/v0.1.0/com.comos-federation.connector-0.1.0-linux-amd64.tar.gz",
+      "bundle_sha256": "d6d5ea8917cc41a8a90f9ce9b7980d97fddf86bc1b1dfd934b92b8bfc92cff5b",
+      "bundles": {
+        "linux/amd64": {
+          "bundle_url": "https://github.com/ronrey/comos-pilot-connector/releases/download/v0.1.0/com.comos-federation.connector-0.1.0-linux-amd64.tar.gz",
+          "bundle_sha256": "d6d5ea8917cc41a8a90f9ce9b7980d97fddf86bc1b1dfd934b92b8bfc92cff5b"
+        },
+        "linux/arm64": {
+          "bundle_url": "https://github.com/ronrey/comos-pilot-connector/releases/download/v0.1.0/com.comos-federation.connector-0.1.0-linux-arm64.tar.gz",
+          "bundle_sha256": "0df3f644db6416cb1d5265ed0a8b93432bcede0a413853d5f28fb5947bb1b0db"
+        },
+        "darwin/amd64": {
+          "bundle_url": "https://github.com/ronrey/comos-pilot-connector/releases/download/v0.1.0/com.comos-federation.connector-0.1.0-darwin-amd64.tar.gz",
+          "bundle_sha256": "fee02b5348aed47799792f0a8b04442a155117e838c58be8eca19ea2b53404ae"
+        },
+        "darwin/arm64": {
+          "bundle_url": "https://github.com/ronrey/comos-pilot-connector/releases/download/v0.1.0/com.comos-federation.connector-0.1.0-darwin-arm64.tar.gz",
+          "bundle_sha256": "40955be72710491059a5d4a4dd9ab1d34195356d75c4d7d824755a31c3f18852"
+        }
+      },
+      "display_name": "ComOS Federation",
+      "vendor": "ComOS Federation, Inc.",
+      "categories": [
+        "commerce",
+        "retail",
+        "payments"
+      ],
+      "bundle_size": 2542631,
+      "source_url": "https://github.com/ronrey/comos-pilot-connector",
+      "license": "AGPL-3.0-or-later",
+      "metadata_url": "https://raw.githubusercontent.com/pilot-protocol/pilotprotocol/main/catalogue/apps/com.comos-federation.connector/metadata.json",
+      "metadata_sha256": "5b02c5ee4e433ce5978c3e8743f67791c2b7026811db4ff03ca9ac4764cbecb2"
     }
   ]
 }


### PR DESCRIPTION
Adds the ComOS Federation connector to the catalogue: a thin read-only client for the ComOS commerce network's public surfaces (12 methods, each proxying one tokenless tool on the federation gateway over HTTPS).

Per `catalogue/README.md`:

- `catalogue.json` entry (v2): per-platform `bundles` map for linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, with linux/amd64 as the back-compat primary; `metadata_url` + `metadata_sha256` pin the detail doc added in the same commit.
- `apps/com.comos-federation.connector/metadata.json`: detail doc with methods, changelog, vendor, compat.
- Bundles are GitHub release assets (https://github.com/ronrey/comos-pilot-connector/releases/tag/v0.1.0); each bundle's manifest is sha-pinned and publisher-signed (`ed25519:IB9iTy70SyMHnQjG1rMtOoXf3KIE3uDZpElGpBw5fUw=`). The manifest's only network grant is `net.dial` to `mcp.comos-federation.com`, rate-limited 120/min. No `fs.*` grants; the connector holds no credentials and performs no writes.
- Source (AGPL-3.0-or-later): https://github.com/ronrey/comos-pilot-connector — includes a container integration test that installs the bundle through the signed-catalogue path with a staging catalogue and round-trips `comos.help` against the live gateway via `pilotctl appstore call`.

`catalogue.json.sig` is not updated here — the catalogue signing key lives with your release pipeline, so this needs a re-sign at merge.

Happy to adjust the entry, id, categories, or listing copy to fit house conventions.